### PR TITLE
Improve test speed

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -55,4 +55,4 @@ jobs:
     - name: Test with pytest and keycloak test container
       working-directory: ./backend/tests
       run: |
-        pytest
+        pytest -n 8

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -419,6 +419,20 @@ ssh = ["paramiko (>=2.4.3)"]
 websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "flask"
 version = "3.0.3"
 description = "A simple framework for building complex web applications."
@@ -1136,6 +1150,26 @@ pytest = ">=6.2"
 setuptools = "*"
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1642,4 +1676,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2ff1bbc286ca6d7a180382b6584549ff00a4b9693911ff9fcdb8452f8b2b1510"
+content-hash = "2d5b2c9dcad138b82daa50825fb94986b0a8485232a349ae3938a61cc88c8d2c"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ flask-cors = "^5.0.0"
 flask-jwt-extended = "^4.6.0"
 cryptography = "^43.0.1"
 alembic = "^1.13.3"
+pytest-xdist = "^3.6.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,7 +16,7 @@ from util.auth_util import fetch_public_key
 
 @pytest.fixture(scope='function')
 def postgres(request):
-    with PostgresContainer("postgres:16") as postgres:
+    with PostgresContainer("postgres:16-alpine") as postgres:
         db_url = postgres.get_connection_url()
         engine = create_engine(db_url, echo=True)
         Base.metadata.create_all(engine)


### PR DESCRIPTION
Closes #53 

Introduces pytest-xdist as new package, which adds the possibility of using multiple pytest workers for running tests. This significantly improves the speed of the integration tests.